### PR TITLE
feat: add proper discord and mail link. Clean-up miscs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,26 @@
-### Hi there 👋 I'm Louis Forestier, aka Ghalaodh#1086 on Discord.
+# Hi there 👋 I'm Louis Forestier, aka Ghalaodh.
 
-I'm a first year student in a Master's degree in Computer Science, and I'm looking to specialize in graphic programming. 
+I'm a first year student in a Master's degree in Computer Science, and I'm looking to specialize in graphic programming.
 
 ## 🌱 I’m currently studying Graphic programming.
+
 I already have some knowledge in OpenGL and I'm getting my first hands on Vulkan.
 I am also interested in VR and AR. I was able to develop some Virtual Reality applications on Unity for MetaQuest 2, I would now like to discover augmented reality.
 
 ## 🔭 I’m currently working on VR app at <a href="https://www.serli.com/">SERLI</a>.
+
 I was able to use my knowledge of Unity and MetaQuest for this project. For now, we are studying the possibilities of a native application in C++ with OpenXR and OpenGL.
+
 <p align="center">
 <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=louisforestier&layout=compact&theme=gotham" />
 </p>
 
 ## 📫 How to reach me:
-LinkedIn: <a href="https://linkedin.com/in/louis-forestier"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg"  height="15" width="15"/></a>
 
-Mail: loforestier@laposte.net
+- Discord : <a href="https://discordapp.com/users/195970053307367424">Ghalaodh#1086</a>
+- LinkedIn: <a href="https://linkedin.com/in/louis-forestier"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg"  height="20" width="20"/></a>
+- Mail: <a href="mailto:loforestier@laposte.net">loforestier@laposte.net</a>
 
-<!--
-**louisforestier/louisforestier** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
-Here are some ideas to get you started:
-
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
-
-## :rocket: Visitors 
+## :rocket: Visitors
 
 <p><img align="center" src="https://visitor-badge.glitch.me/badge?page_id=louisforestier.visitor" alt="LouisForestierVisitor" /></p>


### PR DESCRIPTION
# Added

- Ultra-intuitive reach-me listing for fast discord DMs and even faster emails.
- Header of the size of an HEADER, not just a header. 
- Dumb-proof discord link.

# Fix

- Ugly trailing whitespaces.
- Useless comments (improve readability).
- Resize Linkedin logo for easy clicks.